### PR TITLE
Resolves #38 by making a layout for simplified pages

### DIFF
--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -1,0 +1,92 @@
+---
+layout: compress
+---
+<!doctype html>
+<html dir="{% if page.html.dir %}{{ page.html.dir }}{% else %}{{ site.html.dir }}{% endif %}"
+  lang="{% if page.html.lang %}{{ page.html.lang }}{% else %}{{ site.html.lang }}{% endif %}"
+  prefix="og: http://ogp.me/ns#"
+>
+  <head>
+    <meta charset="{{ site.encoding }}" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+    <meta name="MobileOptimized" content="width" />
+    <meta name="HandheldFriendly" content="true" />
+    {% comment %}<!-- ^ The above meta tags are blocking, so don't move them. -->{% endcomment %}
+
+    {% comment %}<!-- The rest of the html <head> is in a separate include. This file was getting big. -->{% endcomment %}
+    {% include head/head.html %}
+  </head>
+  <body class="page--{% if page.front %}front{% else %}{{ page.url | slugify }}{% endif %} webp--disabled"
+    itemscope itemtype="http://schema.org/{% if page.schema.type %}{{ page.schema.type }}{% else %}{{ site.schema.type }}{% endif %}">
+
+    {% comment %}<!--
+      We don't support old Internet Explorer versions.
+      Also, we want to give users of different abilities and device types the ability to skip the nav to the content.
+    -->{% endcomment %}
+    {% include head/ie-upgrade-warning.html %}
+    {% include head/a11y--skip-hide.html %}
+
+    {% comment %}<!--
+      The site alerts need not be only on the front page, though they may not render on markdown pages.
+      Swap the alerts in collections/_sections/alerts.html
+    -->{% endcomment %}
+    {% if page.front and false %}
+      {% include organisms/section.html
+        mode="ref"
+        slug="alerts"
+      %}
+    {% endif %}
+
+    {% comment %}<!-- Special pre-header for front page. Remove the "and false" part to enable. -->{% endcomment %}
+    {% if page.front and false %}
+      {% include organisms/header--pre.html %}
+    {% endif %}
+
+    {% comment %}<!-- Set to true or remove conditional to show the utility menu above the header. -->{% endcomment %}
+    {% if false %}
+      {% include organisms/utility.html %}
+    {% endif %}
+
+    {% comment %}<!-- Set to true or remove conditional to show the external utility menu above the header. -->{% endcomment %}
+    {% if false %}
+      {% include organisms/utility-external.html %}
+    {% endif %}
+
+    {% comment %}<!-- This can be replaced with header, header and nav separately, etc. -->{% endcomment %}
+    {% include organisms/header.html %}
+
+    <main class="page" id="main-content">
+      {% comment %}<!-- The 'hero' title area that appears on all non-front pages. -->{% endcomment %}
+      {% include organisms/hero.html %}
+
+      {% comment %}<!--
+        To properly manage templates, be sure to put content-specific liquid tags in the content-type-specific layout files
+        rather than this one using conditions.
+      -->{% endcomment %}
+      {{ content }}
+
+      {% comment %}<!-- Sections typically only work on pages and HTML files (markdown supports less). -->{% endcomment %}
+      {% if page.sections and false %}
+        {% for slug in page.sections %}
+          {{ site.sections | where:"slug",slug | first }}
+        {% endfor %}
+      {% endif %}
+    </main>
+
+    {% if jekyll.environment != "development" and site.no_pre_commit_dependencies != true %}
+      <script async defer src="{{ site.subpath }}/assets/js/pre-commit-dependency.js"></script>
+    {% else %}
+      <script async defer src="{{ site.subpath }}/assets/js/behavior.js"></script>
+    {% endif %}
+
+    {% if page.attached.js[0] %}
+      {% for js in page.attached.js %}
+        <script async defer src="{{ site.subpath }}{{ js }}"></script>
+      {% endfor %}
+    {% endif %}
+
+    {% if site.google_analytics %} {% include head/google_analytics.html %}{% endif %}
+    {% if site.snipcart.api_key %}{% include head/snipcart.html %}{% endif %}
+  </body>
+</html>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: landing
 ---
 
 {% assign extension = page.name | slice: -2, 2 %}


### PR DESCRIPTION
I don't particularly like this solve because it doubles the tech debt for maintaining default.html and cannot be controlled for individual pages (only at the content-type layout level).

Will revisit this somebody to add a frontmatter flag that operates on conditional logic in what will become a more-complex default.html.

Leaving this PR open for that purpose but not requesting a review at this time,