### PR TITLE
docs: expand atom accessibility guidance

### DIFF
--- a/_includes/atoms/heading.html
+++ b/_includes/atoms/heading.html
@@ -32,9 +32,14 @@ Headings provide your document with an hierarchical outline.
 {% endcapture %}
 
 {% capture accessibility %}
-A common navigation technique for users of screen reading software is jumping from heading to heading to quickly determine
-the content of the page. Because of this, it is important to not skip one or more heading levels. Doing so may create confusion,
-as the person navigating this way may be left wondering where the missing heading is.
+Headings communicate the structure of a page, and assistive technologies can use them for in-page navigation. Choose a
+`level` that matches the surrounding outline instead of choosing a heading for its visual size.
+
+Avoid skipping heading levels when opening new sections. For example, do not move from an `<h2>` directly to an `<h4>`
+unless the intervening section has ended. The W3C WAI headings tutorial notes that skipped ranks can be confusing for
+people navigating by heading.
+
+@see [W3C WAI tutorial on headings](https://www.w3.org/WAI/tutorials/page-structure/headings/)
 {% endcapture %}
 
 {% capture props %}

--- a/_includes/atoms/icon.html
+++ b/_includes/atoms/icon.html
@@ -21,8 +21,14 @@ Icons visually represent a small concept. They're used to provide both visual gu
 {% endcapture %}
 
 {% capture accessibility %}
-Since icons are primarily visual, it's important that icons not be the only way of conveying meaning. Textual labels are
-important to avoid inaccessible and unusable "mystery meat navigation".
+Icons must not be the only way to convey meaning. If the icon is part of a link, button, or other control, make sure the
+control has an accessible text label from visible text, `aria-label`, or another appropriate labeling technique.
+
+If an icon is decorative and the same meaning is already provided in text, hide the icon from assistive technologies so it
+does not create duplicate or noisy output. MDN's `aria-hidden` guidance notes that hidden content is removed from the
+accessibility tree.
+
+@see [MDN aria-hidden reference](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-hidden)
 {% endcapture %}
 
 {% capture props %}

--- a/_includes/atoms/image.html
+++ b/_includes/atoms/image.html
@@ -57,9 +57,15 @@ checks to insert next-generation optimized images if available.
 {% endcapture %}
 
 {% capture accessibility %}
-It is required for all images to have an alt attribute. If an image has no communicative value (ie. it is purely decorative),
-its alt attribute should be an empty string. Otherwise, the alt attribute's text should be a description of the image's role
-in the corpus of the page.
+Every image needs an `alt` value, but the right value depends on the image's purpose in the current page. Use concise alt
+text when the image communicates information or acts as a link, and use an empty string when the image is purely decorative.
+
+When an image is wrapped in a link, the alt text becomes part of the link's accessible name, so describe the link
+destination or action instead of the pixels. For complex images, provide the short identification in `alt` and put the
+longer explanation in nearby page text or a linked description.
+
+@see [W3C WAI alt decision tree](https://www.w3.org/WAI/tutorials/images/decision-tree/)
+@see [WCAG Understanding 1.1.1: Non-text Content](https://www.w3.org/WAI/WCAG22/Understanding/non-text-content.html)
 {% endcapture %}
 
 {% capture props %}

--- a/_includes/atoms/spacer.html
+++ b/_includes/atoms/spacer.html
@@ -21,7 +21,14 @@ Spacers are only available in 1, 2, 4, 8, 16, and 32 sizes. Other size values wi
 {% endcapture %}
 
 {% capture accessibility %}
-Spacers are empty `<div>` elements with no semantic value. Spacers should not be used for any semantic purpose.
+Spacers are empty `<div>` elements with no semantic value. Use them only for visual spacing, not to imply grouping,
+section breaks, reading order, or hierarchy.
+
+If the page needs structure, use semantic HTML such as headings, lists, landmarks, or sectioning elements. WCAG's
+non-text-content guidance treats purely decorative content differently from content that communicates information; spacers
+should stay decorative.
+
+@see [WCAG Understanding 1.1.1: Non-text Content](https://www.w3.org/WAI/WCAG22/Understanding/non-text-content.html)
 {% endcapture %}
 
 {% capture props %}


### PR DESCRIPTION
Fixes #1.

This expands the accessibility guidance in the atom docblocks without changing the rendered component behavior.

Changed docblocks:
- `atoms/heading.html`: explain choosing heading levels from the document outline and avoiding skipped ranks.
- `atoms/icon.html`: explain when icons need accessible labels and when decorative icons should be hidden from assistive technologies.
- `atoms/image.html`: clarify purpose-based alt text, decorative images, linked images, and complex images.
- `atoms/spacer.html`: clarify that spacers are decorative only and should not communicate structure.

The added guidance links to W3C WAI, WCAG, and MDN reference pages from the docblocks.

Validation:
- `git diff --check`
- Direct content check confirmed the new W3C/WCAG/MDN references are present in the four docblocks.
- `npm install --legacy-peer-deps` completed.
- `npm run jest` was attempted after dependency install, but the Puppeteer tests expect a site already running at `http://localhost:4000` and failed with `net::ERR_CONNECTION_REFUSED`.
- `bundle install --path vendor/bundle` was attempted, but the local system Ruby is `2.6.10` and the current unpinned dependency resolution selected `ffi-1.17.4`, which requires Ruby `>= 3.0`. Because of that local Ruby/toolchain mismatch, I could not start the Jekyll site locally for the Puppeteer tests.
